### PR TITLE
Remove Multimethod

### DIFF
--- a/src/clojulator/calculator/evaluator.cljc
+++ b/src/clojulator/calculator/evaluator.cljc
@@ -1,35 +1,30 @@
-(ns clojulator.calculator.evaluator)
-
-(declare map-eval-reduce)
+(ns clojulator.calculator.evaluator
+  (:require [clojure.walk :as walk]))
 
 (defn evaluate
-  "Evaluates an AST node and returns the result."
-  [node history]
-  (let [node-type (first node)
-        op ({:node/Plus +
-             :node/Minus -
-             :node/Star *
-             :node/Slash /
-             :node/Caret Math/pow
-             :node/Modulo mod}
-            node-type)]
-    (case node-type
-      :node/Number (second node)
-      :node/Env (let [[p1 p2 p3] history]
-                  (case (second node)
-                    "p1" p1
-                    "p2" p2
-                    "p3" p3))
-      :node/Group (evaluate (second node) history)
-      ;; Special case for unary operators
-      (if (= 1 (count (rest node)))
-        (op (evaluate (first (rest node)) history))
-        (map-eval-reduce history op (rest node))))))
-
-(defn map-eval-reduce
-  "Helper function for mapping and reducing 
-  over a collection of AST nodes."
-  [history f coll]
-  (->> coll
-       (map #(evaluate % history))
-       (reduce f)))
+  "Evaluates an AST using post-order traversal and returns the result."
+  [ast history]
+  (walk/postwalk
+   (fn [node]
+     (if (vector? node)
+       (let [[node-type & children] node
+             op ({:node/Plus +
+                  :node/Minus -
+                  :node/Star *
+                  :node/Slash /
+                  :node/Caret Math/pow
+                  :node/Modulo mod} node-type)]
+         (case node-type
+           :node/Number (first children)
+           :node/Env (let [[p1 p2 p3] history]
+                       (case (first children)
+                         "p1" p1
+                         "p2" p2
+                         "p3" p3))
+           :node/Group (first children)
+          ;; Special case for unary operators
+           (if (= 1 (count children))
+             (op (first children))
+             (apply op children))))
+       node))
+   ast))


### PR DESCRIPTION
Refactor the evaluator so that it is not defined using a multimethod. A simple approach using `case` seems to be a better option for this use case.